### PR TITLE
Fix typo in CLI response string

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -62,7 +62,7 @@ def instrument_context(current_settings):
 def command(message: str):
     with instrument_context(current_settings) as instrument:
         resp = instrument.query(str(message))
-        typer.echo(f"repsponse: \n{resp}")
+        typer.echo(f"response: \n{resp}")
 
 
 @app.command()


### PR DESCRIPTION
## Summary
- fix `repsponse` typo in `command` function

## Testing
- `python -m py_compile src/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_6853b49b7e9c832bb8643e00742db3d7