### PR TITLE
Fix ls docstring

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -81,10 +81,10 @@ def errorlog(truncate: Annotated[Optional[bool], typer.Option()] = True):
 
 @app.command()
 def ls():
-    """
-    List all connected instruments and retrieve their IDN.
-    Args:
-        current_settings (dict): The current settings containing the IP address of the instruments.
+    """List connected instruments and display their IDN.
+
+    The function relies on the global ``current_settings`` to access instrument
+    configuration and does not take any arguments.
     """
     console = Console()
     temp_settings = current_settings.copy()


### PR DESCRIPTION
## Summary
- remove unused argument from `ls` docstring
- mention the function uses global `current_settings`

## Testing
- `python -m py_compile src/cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6853b4b68714832b88cbcc817a3dc1f3